### PR TITLE
doc: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # actions-testing-repo
 
-Just testing the `[skip ci]` functinoality here.
+Just testing the `[skip ci]` functionality here.
 This addition shouldn't trigger CI if I do rebase merge on the PR?


### PR DESCRIPTION
now this HEAD of the PR has [skip ci] but let's see what happens with
merge commits.